### PR TITLE
Add CI build configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+
+language: python
+
+sudo: required
+
+services:
+  - docker
+
+script:
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then
+      TAG="latest";
+    else
+      TAG="$TRAVIS_BRANCH";
+    fi
+  - docker build -t opentosca/engine-ia:$TAG ./engine-ia
+  - docker build -t opentosca/engine-plan:$TAG ./engine-plan
+
+after_success:
+  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASSWORD;
+    docker push opentosca/engine-ia;
+    docker push opentosca/engine-plan;


### PR DESCRIPTION
Currently we going to build the 'engine' images with TravisCI in order to deploy those images to the official Docker Hub. The builds for 'container', 'ui', and 'winery' will be part of their actual repository soon.